### PR TITLE
Remove design server check

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -19,6 +19,9 @@ export LI_TOKEN=YOUR_TOKEN
 
 # Publish the config in /tmp/project
 ./bin/run project-config:publish -d tmp/project
+
+# Run a local design server serving built design jsons from dist/designs
+./bin/run design-server:start -d dist/designs
 ```
 
 

--- a/src/commands/design-server/start.js
+++ b/src/commands/design-server/start.js
@@ -32,17 +32,8 @@ class DesignServerCommand extends Command {
     let host
     const {port, verbose, dist, assets, basePath} = this.parse(DesignServerCommand).flags
 
-    const log = verbose && {prettyPrint: true}
-
-    // Check at startup if any design configs can be found
-    const initialDesigns = await initDesigns({dist})
-    if (!Object.keys(initialDesigns).length) {
-      this.log(chalk.red('✕ No design configs found'))
-      return
-    }
-
     const fastify = require('fastify')({
-      logger: log
+      logger: verbose ? {prettyPrint: true} : undefined
     })
 
     fastify.register(require('fastify-cors'))
@@ -110,7 +101,7 @@ class DesignServerCommand extends Command {
     fastify.listen(port, (err, address) => {
       if (err) throw err
       host = address
-      if (!log) this.log(chalk.green(`server listening at ${address}`))
+      if (!verbose) this.log(chalk.green(`server listening at ${address}`))
     })
   }
 }


### PR DESCRIPTION
## Changelog

* Remove check for designs at startup
  The server might be started before a design config exists, without the check at startup this scenario is now supported as well.