### PR TITLE
Command argument Improvements

### DIFF
--- a/src/commands/project-config/download.js
+++ b/src/commands/project-config/download.js
@@ -11,7 +11,7 @@ const errorReporter = require('../../lib/api/error_reporter')
 
 const description = `Download a project configuration`
 const commandFlags = {
-  token: {...sharedFlags.token, required: true},
+  token: {...sharedFlags.configReadToken, required: true},
   host: sharedFlags.host,
   dist: sharedFlags.dist,
   format: flags.string({

--- a/src/commands/project-config/drafts.js
+++ b/src/commands/project-config/drafts.js
@@ -7,7 +7,7 @@ const errorReporter = require('../../lib/api/error_reporter')
 
 const description = `List project configuration drafts`
 const commandFlags = {
-  token: {...sharedFlags.token, required: true},
+  token: {...sharedFlags.configReadToken, required: true},
   host: sharedFlags.host
 }
 

--- a/src/commands/project-config/plan.js
+++ b/src/commands/project-config/plan.js
@@ -12,7 +12,8 @@ const commandFlags = {
   host: sharedFlags.host,
   dist: flags.string({
     char: 'd',
-    description: 'The folder or filename where to download to.'
+    required: true,
+    description: 'The folder or filename to the channelConfig.'
   })
 }
 

--- a/src/commands/project-config/plan.js
+++ b/src/commands/project-config/plan.js
@@ -8,7 +8,7 @@ const readChannelConfig = require('../../lib/read_channel_config')
 
 const description = `See what would be updated in a publish command`
 const commandFlags = {
-  token: {...sharedFlags.token, required: true},
+  token: {...sharedFlags.configWriteToken, required: true},
   host: sharedFlags.host,
   dist: flags.string({
     char: 'd',

--- a/src/commands/project-config/publish.js
+++ b/src/commands/project-config/publish.js
@@ -14,7 +14,8 @@ const commandFlags = {
   host: sharedFlags.host,
   dist: flags.string({
     char: 'd',
-    description: 'The folder to publish from.'
+    required: true,
+    description: 'The folder or filename to the channelConfig.'
   })
 }
 

--- a/src/commands/project-config/publish.js
+++ b/src/commands/project-config/publish.js
@@ -10,7 +10,7 @@ const updateRevisionNumber = require('../../lib/update_revision_number')
 
 const description = `Publish a ChannelConfig to your project`
 const commandFlags = {
-  token: {...sharedFlags.token, required: true},
+  token: {...sharedFlags.configWriteToken, required: true},
   host: sharedFlags.host,
   dist: flags.string({
     char: 'd',

--- a/src/commands/project-config/upload.js
+++ b/src/commands/project-config/upload.js
@@ -13,7 +13,8 @@ const commandFlags = {
   host: sharedFlags.host,
   dist: flags.string({
     char: 'd',
-    description: 'The folder or filename where to download to.'
+    required: true,
+    description: 'The folder or filename to the channelConfig.'
   }),
   draftName: flags.string({
     description: 'The name of the draft the config will be saved under.',

--- a/src/commands/project-config/upload.js
+++ b/src/commands/project-config/upload.js
@@ -9,7 +9,7 @@ const readChannelConfig = require('../../lib/read_channel_config')
 
 const description = `Upload a ChannelConfig into a draft for your project`
 const commandFlags = {
-  token: {...sharedFlags.token, required: true},
+  token: {...sharedFlags.configWriteToken, required: true},
   host: sharedFlags.host,
   dist: flags.string({
     char: 'd',

--- a/src/commands/project-config/upload_assets.js
+++ b/src/commands/project-config/upload_assets.js
@@ -7,7 +7,7 @@ const liApi = require('../../lib/api/livingdocs_api')
 
 const description = `Upload assets to your project`
 const commandFlags = {
-  token: {...sharedFlags.token, required: true},
+  token: {...sharedFlags.configWriteToken, required: true},
   host: sharedFlags.host,
   assets: flags.string({
     char: 'a',

--- a/src/lib/cli/shared_flags.js
+++ b/src/lib/cli/shared_flags.js
@@ -1,10 +1,16 @@
 const {flags} = require('@oclif/command')
 
 module.exports = {
-  token: flags.string({
+  configWriteToken: flags.string({
     char: 't',
     env: 'LI_TOKEN',
-    description: 'The Access Token to your project (needs write permission).\n' +
+    description: 'Access Token for your project (needs `public-api:config:write` permission).\n' +
+      `Can be set by the environment variable 'LI_TOKEN'.`
+  }),
+  configReadToken: flags.string({
+    char: 't',
+    env: 'LI_TOKEN',
+    description: 'Access Token for your project (needs `public-api:config:read` permission).\n' +
       `Can be set by the environment variable 'LI_TOKEN'.`
   }),
   host: flags.string({

--- a/src/lib/read_channel_config.js
+++ b/src/lib/read_channel_config.js
@@ -3,8 +3,7 @@ const _map = require('lodash/map')
 const parseComponents = require('./parsing/parse_components')
 
 module.exports = async function ({source}) {
-  const rootFolder = path.resolve(source)
-  const channelConfig = require(rootFolder)
+  const {rootFolder, channelConfig} = loadChannelConfig(source)
 
   if (channelConfig.components) {
     let needsLoading = false
@@ -22,4 +21,14 @@ module.exports = async function ({source}) {
     }
   }
   return channelConfig
+}
+
+function loadChannelConfig (source) {
+  try {
+    const rootFolder = path.resolve(source)
+    const channelConfig = require(rootFolder)
+    return {rootFolder, channelConfig}
+  } catch (err) {
+    throw new Error(`Could not load channel config from path '${source}'`)
+  }
 }


### PR DESCRIPTION
## Changelog

- show the correct token permissions in every command
- require to pass a folder param in commands that require it
- better error messages when the folder where the channel config is located cant be loaded