### PR TITLE
Better error message for channel config errors

### DIFF
--- a/src/lib/read_channel_config.js
+++ b/src/lib/read_channel_config.js
@@ -29,6 +29,8 @@ function loadChannelConfig (source) {
     const channelConfig = require(rootFolder)
     return {rootFolder, channelConfig}
   } catch (err) {
-    throw new Error(`Could not load channel config from path '${source}'`)
+    throw new Error(`Could not load channel config from path '${source}'.
+      Error Stack: ${err.stack}
+      Error: ${err.message}`)
   }
 }


### PR DESCRIPTION
From
```
$ ./bin/run project-config:publish -d ~/ov-channel-config
 ›   Warning: livingdocs-cli update available from 0.0.0 to 1.1.3.
✕ Parsing Failed
Error: Could not load channel config from path '/Users/gabrielhase/ov-channel-config'
    at loadChannelConfig (~/projects/livingdocs/core/livingdocs-cli/src/lib/read_channel_config.js:32:11)
    at module.exports (~/projects/livingdocs/core/livingdocs-cli/src/lib/read_channel_config.js:6:39)
    at PublishCommand.run (~/projects/livingdocs/core/livingdocs-cli/src/commands/project-config/publish.js:31:26)
    at PublishCommand._run (~/projects/livingdocs/core/livingdocs-cli/node_modules/@oclif/command/lib/command.js:44:31)
```

To
```
$ ./bin/run project-config:publish -d ~/ov-channel-config
 ›   Warning: livingdocs-cli update available from 0.0.0 to 1.1.3.
✕ Parsing Failed
Error: Could not load channel config from path '/Users/gabrielhase/ov-channel-config'.
      Error Stack: /Users/gabrielhase/ov-channel-config/components/asset-content.js:11
  html: '<article class="o-asset-content"><header class="o-asset-content__header" doc-container="header"></header><main class="o-asset-content__main" doc-container="main"></main></article>'
  ^^^^
SyntaxError: Unexpected identifier
    at Object.<anonymous> (~/ov-channel-config/index.js:65:5)
      Error: Unexpected identifier
    at loadChannelConfig (~/projects/livingdocs/core/livingdocs-cli/src/lib/read_channel_config.js:32:11)
    at module.exports (~/projects/livingdocs/core/livingdocs-cli/src/lib/read_channel_config.js:6:39)
    at PublishCommand.run (~/projects/livingdocs/core/livingdocs-cli/src/commands/project-config/publish.js:31:26)
    at PublishCommand._run (~/projects/livingdocs/core/livingdocs-cli/node_modules/@oclif/command/lib/command.js:44:31)
```