### PR TITLE
Publish diff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "chalk": "^2.4.2",
         "cheerio": "^1.0.0-rc.3",
         "dedent": "^0.7.0",
+        "diff": "^5.0.0",
         "fastify": "^3.25.3",
         "fastify-cors": "^6.0.2",
         "fastify-static": "^4.5.0",
@@ -2710,10 +2711,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -5701,6 +5701,15 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/mocha/node_modules/glob": {
@@ -10377,10 +10386,9 @@
       "dev": true
     },
     "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -12640,6 +12648,12 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
         },
         "glob": {
           "version": "7.1.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "chalk": "^2.4.2",
     "cheerio": "^1.0.0-rc.3",
     "dedent": "^0.7.0",
+    "diff": "^5.0.0",
     "fastify": "^3.25.3",
     "fastify-cors": "^6.0.2",
     "fastify-static": "^4.5.0",

--- a/src/commands/project-config/publish.js
+++ b/src/commands/project-config/publish.js
@@ -33,11 +33,15 @@ class PublishCommand extends Command {
         throw err
       })
 
+    let ok = false
     await liApi.plan({host, token, channelConfig: config})
       .then((result) => {
+        ok = result.ok
         resultReporter(result, this.log)
       })
       .catch(reportError)
+
+    if (!ok) return
 
     const answers = await inquirer.prompt([{
       name: 'continue',


### PR DESCRIPTION
## Changelog

- 🎁 Show diff of patches in `project-config:plan` and `project-config:publish` (This only works if the livingdocs server returns `valueBefore` values in patches. This is not the case before the march 2022 release)

Example CLI output:

<img width="620" alt="Screenshot 2022-01-04 at 18 46 55" src="https://user-images.githubusercontent.com/47606/148103830-f646b848-4f19-4bfd-8321-a2768a08ef7b.png">

