### PR TITLE
Use source instead of dist in plan and publish commands

### DIFF
--- a/src/commands/config/print.js
+++ b/src/commands/config/print.js
@@ -21,13 +21,15 @@ class ListConfigCommand extends Command {
 
     this.printVar(`LI_HOST`, 'host', sessionConfig)
     this.printVar(`LI_TOKEN`, 'token', sessionConfig)
+    this.printVar(`LI_SOURCE_FOLDER`, 'sourceFolder', sessionConfig)
     this.printVar(`LI_DIST_FOLDER`, 'distFolder', sessionConfig)
   }
 
   printVar (name, prop, sessionConfig) {
     const varObj = getVar(name, prop, sessionConfig)
 
-    this.log(chalk.green(`${name}`), chalk.gray(` (source: ${varObj.source})`))
+    if (varObj.source) this.log(chalk.green(`${name}`), chalk.gray(` (source: ${varObj.source})`))
+    else this.log(chalk.green(`${name}`))
     this.log(chalk.gray(`${varObj.value}\n`))
   }
 }
@@ -51,7 +53,7 @@ function getVar (key, prop, sessionConfig) {
   } else {
     return {
       value: '[undefined]',
-      source: 'not set'
+      source: undefined
     }
   }
 }

--- a/src/commands/project-config/plan.js
+++ b/src/commands/project-config/plan.js
@@ -13,18 +13,17 @@ class PlanCommand extends Command {
     env: sharedFlags.env,
     token: {...sharedFlags.configWriteToken, required: true},
     host: {...sharedFlags.host, required: true},
-    dist: {
-      ...sharedFlags.dist,
-      required: true,
-      description: 'The folder or filename to the project config.'
-    }
+    source: {...sharedFlags.source},
+    dist: {...sharedFlags.dist}
   }
 
   async run () {
-    const {token, host, dist} = this.parse(PlanCommand).flags
+    const {token, host, source, dist} = this.parse(PlanCommand).flags
     const reportError = errorReporter(this.log, host, {verbose: true})
 
-    const config = await readChannelConfig({source: dist})
+    if (!source && !dist) throw new Error('Missing a source param')
+
+    const config = await readChannelConfig({source: source || dist})
 
     await liApi.plan({host, token, channelConfig: config})
       .then((result) => {

--- a/src/commands/project-config/publish.js
+++ b/src/commands/project-config/publish.js
@@ -16,18 +16,17 @@ class PublishCommand extends Command {
     env: sharedFlags.env,
     token: {...sharedFlags.configWriteToken, required: true},
     host: {...sharedFlags.host, required: true},
-    dist: {
-      ...sharedFlags.dist,
-      required: true,
-      description: 'The folder or filename to the project config.'
-    }
+    source: {...sharedFlags.source},
+    dist: {...sharedFlags.dist}
   }
 
   async run () {
-    const {token, host, dist} = this.parse(PublishCommand).flags
+    const {token, host, source, dist} = this.parse(PublishCommand).flags
     const reportError = errorReporter(this.log, host, {verbose: true})
 
-    const config = await readChannelConfig({source: dist})
+    if (!source && !dist) throw new Error('Missing a source param')
+
+    const config = await readChannelConfig({source: source || dist})
       .catch((err) => {
         this.log(chalk.red('✕ Parsing Failed'))
         throw err
@@ -56,7 +55,7 @@ class PublishCommand extends Command {
       .then((result) => {
         resultReporter(result, this.log)
         updateRevisionNumber({
-          source: dist,
+          source: source || dist,
           revisionNumberBefore: config.$baseRevision,
           revisionNumber: result.revisionNumber
         })

--- a/src/commands/project-config/upload.js
+++ b/src/commands/project-config/upload.js
@@ -15,11 +15,10 @@ class UploadCommand extends Command {
     env: sharedFlags.env,
     token: {...sharedFlags.configWriteToken, required: true},
     host: {...sharedFlags.host, required: true},
-    dist: flags.string({
-      char: 'd',
-      required: true,
-      description: 'The folder or filename to the channelConfig.'
-    }),
+    source: {
+      ...sharedFlags.source,
+      required: true
+    },
     draftName: flags.string({
       description: 'The name of the draft the config will be saved under.',
       required: true
@@ -27,10 +26,10 @@ class UploadCommand extends Command {
   }
 
   async run () {
-    const {token, host, dist} = this.parse(UploadCommand).flags
+    const {token, host, source} = this.parse(UploadCommand).flags
     const reportError = errorReporter(this.log, host, {verbose: true})
 
-    const config = await readChannelConfig({source: dist})
+    const config = await readChannelConfig({source})
       .catch((err) => {
         this.log(chalk.red('✕ Parsing Failed'))
         throw err

--- a/src/lib/cli/shared_flags.js
+++ b/src/lib/cli/shared_flags.js
@@ -66,6 +66,19 @@ module.exports = {
       }
     }
   }),
+  source: flags.string({
+    char: 's',
+    description: 'The folder or filename to the project config.',
+
+    default ({options, flags: givenFlags}) {
+      const sessionConfig = getCliConfig(givenFlags)
+      if (sessionConfig) {
+        return sessionConfig.sourceFolder
+      } else {
+        return process.env.LI_SOURCE_FOLDER
+      }
+    }
+  }),
   designUri: flags.string({
     char: 'u',
     description: 'URL of the design to import',

--- a/test/commands/config_print.test.js
+++ b/test/commands/config_print.test.js
@@ -10,7 +10,7 @@ describe('config:print', function () {
     .command('config:print'.split(' '))
     .it('prints the config when no env vars are set', (ctx) => {
       expect(ctx.stdout).to.contain('LI_HOST  (source: default value)')
-      expect(ctx.stdout).to.contain('LI_TOKEN  (source: not set)')
+      expect(ctx.stdout).to.contain('LI_TOKEN')
     })
 
   test
@@ -43,7 +43,8 @@ describe('config:print (.livingdcos-cli)', function () {
           local:
             host: 'https://dotfile:9071'
             token: 'dotfile-local-token-yaml'
-            distFolder: './project-config/local'
+            sourceFolder: './project-config/local'
+            distFolder: './dist/local'
       `
       await fs.writeFile('./.livingdocs-cli', content)
     })


### PR DESCRIPTION
Related:
 - https://github.com/livingdocsIO/documentation/pull/455
 
## Description

The `project-config:download` command currently uses the same `dist` param as `project-config:plan` and `project-config:publish`. 
 
For setups where the config should only be uploaded this can lead to accidentally overwriting the config. So this PR introduces a source param so we can clearly distinguish params for up- and downloading the config.

## Changelog

* 🍬 Add `source` param to `project-config:plan` and `project-config:publish` (the dist param is still accepted for backwards compatibility)
* 🍬 Add `sourceFolder` param to `.livingdocs-cli` dotfile.
* 🍬 Add `LI_SOURCE_FOLDER` environment variable