### PR TITLE
feat: add param 'address' to start the design-server on

### DIFF
--- a/src/commands/design-server/start.js
+++ b/src/commands/design-server/start.js
@@ -13,6 +13,10 @@ class DesignServerCommand extends Command {
       description: 'The port of the design-server.',
       default: 9030
     }),
+    address: flags.string({
+      char: 'a',
+      description: 'The address of the design-server.'
+    }),
     dist: flags.string({
       char: 'd',
       description: 'The folder to load designs from.',
@@ -29,7 +33,8 @@ class DesignServerCommand extends Command {
 
   async run () {
     let host
-    const {port, verbose, dist, assets, basePath} = this.parse(DesignServerCommand).flags
+    const {port, address: customAddress, verbose, dist, assets, basePath} =
+      this.parse(DesignServerCommand).flags
 
     const fastify = require('fastify')({
       logger: verbose ? {prettyPrint: true} : undefined
@@ -108,7 +113,7 @@ class DesignServerCommand extends Command {
       reply.sendFile(filePath)
     })
 
-    fastify.listen(port, (err, address) => {
+    fastify.listen(port, customAddress, (err, address) => {
       if (err) throw err
       host = address
       if (!verbose) this.log(chalk.green(`server listening at ${address}`))


### PR DESCRIPTION
Relations:
  - Issue: https://github.com/livingdocsIO/livingdocs-planning/issues/4570

## Description

Makes it possible to start the design server on a specified `address`.

## Changelog

- New parameter `address` to specify the address where the **design-server** should start. If not specified, the default is `localhost`

Example

> livingdocs-cli design-server:start --address='some_address'
