### PR TITLE
fix: add '-y' flag for publish command

### DIFF
--- a/src/commands/project-config/publish.js
+++ b/src/commands/project-config/publish.js
@@ -14,6 +14,7 @@ class PublishCommand extends Command {
   static flags = {
     project: sharedFlags.project,
     env: sharedFlags.env,
+    yes: sharedFlags.yes,
     token: {...sharedFlags.configWriteToken, required: true},
     host: {...sharedFlags.host, required: true},
     source: {...sharedFlags.source},
@@ -21,7 +22,7 @@ class PublishCommand extends Command {
   }
 
   async run () {
-    const {token, host, source, dist, env} = this.parse(PublishCommand).flags
+    const {token, host, source, dist, env, yes} = this.parse(PublishCommand).flags
     const reportError = errorReporter(this.log, host, {verbose: true})
 
     if (!source && !dist) throw new Error('Missing a source param')
@@ -46,14 +47,16 @@ class PublishCommand extends Command {
 
     if (!ok) return
 
-    const answers = await inquirer.prompt([{
-      name: 'continue',
-      type: 'confirm',
-      default: false,
-      message: `Are you sure to publish${env ? ` to ${env}` : ''}?`
-    }])
+    if (!yes) {
+      const answers = await inquirer.prompt([{
+        name: 'continue',
+        type: 'confirm',
+        default: false,
+        message: `Are you sure to publish${env ? ` to ${env}` : ''}?`
+      }])
 
-    if (!answers.continue) return
+      if (!answers.continue) return
+    }
 
     await liApi.publish({host, token, channelConfig: config})
       .then((result) => {

--- a/src/lib/api/project_config_result_reporter.js
+++ b/src/lib/api/project_config_result_reporter.js
@@ -70,7 +70,7 @@ module.exports = function ({result, log, omitPatches}) {
   }
 
   if (result.violations) {
-    error(`\nInvalid Config: there are invliad configuration properties`)
+    error(`\nInvalid Config: there are invalid configuration properties`)
 
     for (const err of result.violations) {
       error(` • ${err.pointer}: ${err.message}`)

--- a/src/lib/cli/shared_flags.js
+++ b/src/lib/cli/shared_flags.js
@@ -11,6 +11,11 @@ module.exports = {
     char: 'e',
     description: 'If used configuration options are loaded from .livingdocs-cli file.'
   }),
+  yes: flags.boolean({
+    char: 'y',
+    description: 'Confirm',
+    default () { return !process.stdin.isTTY }
+  }),
   configWriteToken: flags.string({
     char: 't',
     description: 'Access Token for your project (needs `public-api:config:write` permission).\n' +


### PR DESCRIPTION
Relations:
  - Issue: https://github.com/livingdocsIO/livingdocs-planning/issues/4619

## Description

Since v2.1.2 of the cli, there is a prompt during `livingdocs-cli project-config:publish` to confirm whether a publish should happen. Since it is used on ci pipelines, it should be possible to override that using a cli argument.

## Changelog

- The publish command now accepts the `-y` flag, which if it's present, auto-confirms the publishing.
